### PR TITLE
Allow specifying page size as well as ordering by created_at

### DIFF
--- a/func_sig_registry/registry/api_views.py
+++ b/func_sig_registry/registry/api_views.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework import generics
 from rest_framework import viewsets
 from rest_framework import mixins
+from rest_framework import filters
 
 from .models import Signature
 from .tasks import perform_github_import
@@ -25,6 +26,8 @@ class SignatureViewSet(mixins.CreateModelMixin,
     queryset = Signature.objects.all().select_related('bytes_signature')
     serializer_class = SignatureSerializer
     filter_class = SignatureFilter
+    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
+    ordering_fields = ('created_at',)
 
 
 class SolidityImportAPIView(generics.CreateAPIView):

--- a/func_sig_registry/registry/filters.py
+++ b/func_sig_registry/registry/filters.py
@@ -8,13 +8,14 @@ from .models import Signature
 
 
 class SignatureFilter(filters.FilterSet):
+    created_at = filters.AllLookupsFilter(name='created_at')
     text_signature = filters.CharFilter(name='text_signature', lookup_type='icontains')
     bytes_signature = filters.MethodFilter()
     hex_signature = filters.MethodFilter()
 
     class Meta:
         model = Signature
-        fields = ['text_signature', 'bytes_signature', 'hex_signature']
+        fields = ['created_at', 'text_signature', 'bytes_signature', 'hex_signature']
 
     def filter_bytes_signature(self, name, qs, value):
         if len(value) == 4:

--- a/func_sig_registry/registry/pagination.py
+++ b/func_sig_registry/registry/pagination.py
@@ -1,0 +1,5 @@
+from rest_framework import pagination
+
+
+class PageNumberPagination(pagination.PageNumberPagination):
+    page_size_query_param = 'page_size'

--- a/func_sig_registry/registry/serializers.py
+++ b/func_sig_registry/registry/serializers.py
@@ -26,10 +26,10 @@ class SignatureSerializer(serializers.ModelSerializer):
     class Meta:
         model = Signature
         fields = (
-            'id', 'text_signature', 'hex_signature', 'bytes_signature',
+            'id', 'created_at', 'text_signature', 'hex_signature', 'bytes_signature',
         )
         read_only_fields = (
-            'hex_signature', 'bytes_signature',
+            'created_at', 'hex_signature', 'bytes_signature',
         )
 
     def validate_text_signature(self, data):

--- a/func_sig_registry/settings.py
+++ b/func_sig_registry/settings.py
@@ -210,7 +210,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.AllowAny',
     ],
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'func_sig_registry.registry.pagination.PageNumberPagination',
     'PAGE_SIZE': 100,
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework_filters.backends.DjangoFilterBackend',


### PR DESCRIPTION
Fixes #15 

Allow specifying page size with `page_size` as well as ordering with `?ordering=created_at` or `?ordering=-created_at`