### PR TITLE
fix overactive regexp in function sig parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - HUEY_REDIS_HOST=localhost
     - DATABASE_URL=postgres://postgres@localhost/func_sig_registry
-    - SOLC_BINARY="$TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2/solc"
+    #- SOLC_BINARY="$TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2/solc"
   matrix:
     - TOX_ENV=py35-django19
     #- TOX_ENV=py35-contracts
@@ -18,20 +18,20 @@ cache:
   - pip: true
   - directories:
     - $HOME/.ethash
-    - $TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2
-    - $TRAVIS_BUILD_DIR/solc-versions/solidity-0.4.2/build
+    #- $TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2
+    #- $TRAVIS_BUILD_DIR/solc-versions/solidity-0.4.2/build
 before_install:
   - sudo add-apt-repository -y ppa:ethereum/ethereum
   - sudo apt-get update
 install:
-  - ./bin/install_solc-0.4.2.sh
+  #- ./bin/install_solc-0.4.2.sh
   - travis_retry sudo apt-get install -y ethereum
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox
 before_script:
   - psql -c 'create database func_sig_registry;' -U postgres
-  - ls -lah $TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2/
-  - ./solc-versions/solc-0.4.2/solc --version
+  #- ls -lah $TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2/
+  #- ./solc-versions/solc-0.4.2/solc --version
   - mkdir -p $HOME/.ethash
   - geth makedag 0 $HOME/.ethash
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - SOLC_BINARY="$TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2/solc"
   matrix:
     - TOX_ENV=py35-django19
-    - TOX_ENV=py35-contracts
+    #- TOX_ENV=py35-contracts
     - TOX_ENV=flake8
 cache:
   - pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: trusty
 sudo: required
 env:
   global:
-    - HUEY_REDIS_HOST=localhost
+    - REDIS_URL=redis://localhost:6379
     - DATABASE_URL=postgres://postgres@localhost/func_sig_registry
     #- SOLC_BINARY="$TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2/solc"
   matrix:

--- a/func_sig_registry/settings_test.py
+++ b/func_sig_registry/settings_test.py
@@ -4,7 +4,7 @@ import getpass
 os.environ.setdefault('DJANGO_SECRET_KEY', 'not-a-real-secret-key')
 os.environ.setdefault('DJANGO_ALLOWED_HOSTS', '*')
 os.environ.setdefault('DJANGO_SECURE_SSL_REDIRECT', 'False')
-os.environ.setdefault('HUEY_REDIS_HOST', '127.0.0.1')
+os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
 os.environ.setdefault(
     'DATABASE_URL',
     'postgres://{user}@localhost/func_sig_registry'.format(user=getpass.getuser()),

--- a/func_sig_registry/utils/solidity.py
+++ b/func_sig_registry/utils/solidity.py
@@ -49,7 +49,7 @@ ARGUMENT_REGEX = (
 
 def extract_function_name(raw_signature):
     fn_name_match = re.match(
-        '^(?:function\s+)?\s*(?P<fn_name>[a-zA-Z_][a-zA-Z0-9_]*).*\(.*\).*$',
+        '^(?:function\s+)?\s*(?P<fn_name>[a-zA-Z_][a-zA-Z0-9_]*).*\((?P<arglist>.*)\).*$',
         raw_signature,
         flags=re.DOTALL,
     )
@@ -59,7 +59,8 @@ def extract_function_name(raw_signature):
     fn_name = group_dict['fn_name']
     if fn_name == 'function':
         raise ValueError("Bad function name")
-    return fn_name
+    arglist = group_dict['arglist']
+    return fn_name, arglist
 
 
 RAW_FUNCTION_REGEX = (
@@ -136,11 +137,23 @@ FUNCTION_ARGUMENT_TYPES_REGEX = (
 
 
 def normalize_function_signature(raw_signature):
-    fn_name = extract_function_name(raw_signature)
-    raw_arguments = re.findall(FUNCTION_ARGUMENT_TYPES_REGEX, raw_signature)
+    fn_name, args = extract_function_name(raw_signature)
+    raw_arguments = re.findall(FUNCTION_ARGUMENT_TYPES_REGEX, args)
 
     arguments = [
         "".join((to_canonical_type(t), sub))
         for t, sub in raw_arguments
     ]
     return "{fn_name}({fn_args})".format(fn_name=fn_name, fn_args=','.join(arguments))
+
+def test():
+   print(normalize_function_signature("foobar(uint,bytes)"))
+   print(normalize_function_signature("mintToken(uint,bytes)"))
+   print(normalize_function_signature("mint(uint256 nonce, bytes32 challenge_digest)"))
+   # Expected:
+   #foobar(uint256,bytes)
+   #mintToken(uint256,bytes)
+   #mint(uint256,bytes32)
+
+
+#test()

--- a/func_sig_registry/utils/solidity.py
+++ b/func_sig_registry/utils/solidity.py
@@ -146,14 +146,3 @@ def normalize_function_signature(raw_signature):
     ]
     return "{fn_name}({fn_args})".format(fn_name=fn_name, fn_args=','.join(arguments))
 
-def test():
-   print(normalize_function_signature("foobar(uint,bytes)"))
-   print(normalize_function_signature("mintToken(uint,bytes)"))
-   print(normalize_function_signature("mint(uint256 nonce, bytes32 challenge_digest)"))
-   # Expected:
-   #foobar(uint256,bytes)
-   #mintToken(uint256,bytes)
-   #mint(uint256,bytes32)
-
-
-#test()

--- a/func_sig_registry/utils/solidity.py
+++ b/func_sig_registry/utils/solidity.py
@@ -145,4 +145,3 @@ def normalize_function_signature(raw_signature):
         for t, sub in raw_arguments
     ]
     return "{fn_name}({fn_args})".format(fn_name=fn_name, fn_args=','.join(arguments))
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,8 @@ pytest-django==2.9.1
 django-webtest==1.7.9
 WebTest==2.0.21
 factory-boy==2.7.0
-populus==1.4.0
+fake-factory==0.7.4
 hypothesis==3.5.3
 tox==2.4.1
+eth-utils==0.7.4
+eth-abi==0.5.0

--- a/tests/web/api/test_signature_serializer.py
+++ b/tests/web/api/test_signature_serializer.py
@@ -1,7 +1,7 @@
 import pytest
 from func_sig_registry.registry.serializers import SignatureSerializer
 
-from func_sig_registry.utils.encoding import (
+from eth_utils import (
     force_text,
 )
 

--- a/tests/web/registry/test_signature_import_from_raw_text_signature.py
+++ b/tests/web/registry/test_signature_import_from_raw_text_signature.py
@@ -25,5 +25,5 @@ def test_import_from_raw_text_signature(raw_signature, expected, models):
     )
 )
 def test_import_from_raw_text_signature_with_bad_signatures(bad_signature, models):
-    with pytest.raises(ValueError):
-        models.Signature.import_from_raw_text_signature(bad_signature)
+    res = models.Signature.import_from_raw_text_signature(bad_signature)
+    assert res is None

--- a/tests/web/utility/test_make_4byte_signature.py
+++ b/tests/web/utility/test_make_4byte_signature.py
@@ -1,6 +1,6 @@
 import pytest
 
-from func_sig_registry.utils.encoding import (
+from eth_utils import (
     encode_hex,
     force_text,
 )

--- a/tests/web/utility/test_normalize_function_signature.py
+++ b/tests/web/utility/test_normalize_function_signature.py
@@ -55,6 +55,10 @@ from func_sig_registry.utils.solidity import (
         ('foo(uint8[])', 'foo(uint8[])'),
         ('foo(uint8[][2][][3])', 'foo(uint8[][2][][3])'),
         ('foo(uint8[][2][][3], uint, bytes32[3][])', 'foo(uint8[][2][][3],uint256,bytes32[3][])'),
+        # types in method name
+        ('mintToken(uint,address)','mintToken(uint256,address)' ),
+        ('uint()', 'uint()'),
+        ('uint256()', 'uint256()'),
     )
 )
 def test_normalizing_function_signatures(raw_signature, expected):

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ commands=
     django19: py.test {posargs:tests/web}
     contracts: py.test {posargs:tests/contracts}
 passenv=
-    HUEY_REDIS_HOST
-    HUEY_REDIS_PORT
+    REDIS_URL
     DATABASE_URL
     SOLC_BINARY
 setenv=


### PR DESCRIPTION
This fixes https://github.com/pipermerriam/ethereum-function-signature-registry/issues/30 and https://github.com/pipermerriam/ethereum-function-signature-registry/issues/31 . 