### PR TITLE
Remove eth-utils dependency and update tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 services:
   - redis-server
 python:
-  - "3.5"
+  - "3.6"
 dist: trusty
 sudo: required
 env:
@@ -11,8 +11,8 @@ env:
     - DATABASE_URL=postgres://postgres@localhost/func_sig_registry
     #- SOLC_BINARY="$TRAVIS_BUILD_DIR/solc-versions/solc-0.4.2/solc"
   matrix:
-    - TOX_ENV=py35-django19
-    #- TOX_ENV=py35-contracts
+    - TOX_ENV=py36-django19
+    #- TOX_ENV=py36-contracts
     - TOX_ENV=flake8
 cache:
   - pip: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,4 @@ factory-boy==2.7.0
 fake-factory==0.7.4
 hypothesis==3.5.3
 tox==2.4.1
-eth-utils==0.7.4
 eth-abi==0.5.0

--- a/tests/web/api/test_signature_serializer.py
+++ b/tests/web/api/test_signature_serializer.py
@@ -1,9 +1,7 @@
 import pytest
-from func_sig_registry.registry.serializers import SignatureSerializer
 
-from eth_utils import (
-    force_text,
-)
+from func_sig_registry.registry.serializers import SignatureSerializer
+from func_sig_registry.utils.encoding import force_text
 
 
 def test_serialization(factories):

--- a/tests/web/utility/test_make_4byte_signature.py
+++ b/tests/web/utility/test_make_4byte_signature.py
@@ -1,9 +1,5 @@
 import pytest
 
-from eth_utils import (
-    encode_hex,
-    force_text,
-)
 from func_sig_registry.utils.abi import make_4byte_signature
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ exclude=**/migrations/*
 
 [tox]
 envlist=
-    py35-{django19,contracts},
+    py36-{django19,contracts},
     flake8
 skipsdist=True
 
 [testenv]
-basepython=python3.5
+basepython=python3.6
 commands=
     django19: py.test {posargs:tests/web}
     contracts: py.test {posargs:tests/contracts}


### PR DESCRIPTION
### What was wrong?

There was an unnecessary `eth-utils` dependency and some old config settings in `tox.ini`.

### How was it fixed?

Removed `eth-utils` dependent code and updated `tox.ini`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.seriousfacts.com/wp-content/uploads/2017/04/a-red-panda-patti-truesdell.jpg)
