### PR TITLE
Extend Solidity Import API to support Event Signature extraction

### DIFF
--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -9,9 +9,12 @@ from .models import (
     EventSignature,
 )
 
+from func_sig_registry.utils.import_statistics import (
+    retrieve_stats_from_import_results,
+)
+
 from func_sig_registry.utils.abi import (
     is_valid_contract_abi,
-    retrieve_stats_from_import_results,
 )
 
 from func_sig_registry.utils.solidity import (

--- a/func_sig_registry/registry/models.py
+++ b/func_sig_registry/registry/models.py
@@ -107,6 +107,7 @@ class Signature(models.Model):
 
     @classmethod
     def import_from_solidity_file(cls, file_obj):
+        file_obj.seek(0)
         code = force_text(file_obj.read())
         return cls.import_from_solidity_code(code)
 
@@ -224,6 +225,7 @@ class EventSignature(models.Model):
 
     @classmethod
     def import_from_solidity_file(cls, file_obj):
+        file_obj.seek(0)
         code = force_text(file_obj.read())
         return cls.import_from_solidity_code(code)
 

--- a/func_sig_registry/registry/serializers.py
+++ b/func_sig_registry/registry/serializers.py
@@ -18,7 +18,7 @@ from func_sig_registry.utils.solidity import (
 
 
 from .models import (
-    Signature, 
+    Signature,
     EventSignature,
 )
 
@@ -88,23 +88,23 @@ class SolidityImportSerializer(serializers.Serializer):
     num_ignored = serializers.IntegerField(read_only=True)
 
     def create(self, validated_data):
-        stats_function = empty_import_stats()
-        stats_event = empty_import_stats()
+        func_imports = []
+        event_imports = []
 
         if validated_data.get('source_file'):
-            stats_function = retrieve_stats_from_import_results(
-                Signature.import_from_solidity_file(validated_data['source_file'])
-            )
-            stats_event = retrieve_stats_from_import_results(
-                EventSignature.import_from_solidity_file(validated_data['source_file'])
-            )
+            func_imports.extend(Signature.import_from_solidity_file(
+                validated_data['source_file']))
+            event_imports.extend(EventSignature.import_from_solidity_file(
+                validated_data['source_file']))
+
         if validated_data.get('source_code'):
-            stats_function = retrieve_stats_from_import_results(
-                Signature.import_from_solidity_code(validated_data['source_code'])
-            )
-            stats_event = retrieve_stats_from_import_results(
-                EventSignature.import_from_solidity_code(validated_data['source_code'])
-            )
+            func_imports.extend(Signature.import_from_solidity_code(
+                validated_data['source_code']))
+            event_imports.extend(EventSignature.import_from_solidity_code(
+                validated_data['source_code']))
+
+        stats_function = retrieve_stats_from_import_results(func_imports)
+        stats_event = retrieve_stats_from_import_results(event_imports)
 
         return {
             'num_processed':

--- a/func_sig_registry/registry/serializers.py
+++ b/func_sig_registry/registry/serializers.py
@@ -15,7 +15,7 @@ from func_sig_registry.utils.solidity import (
 
 
 from .models import (
-    Signature,
+    Signature, 
     EventSignature,
 )
 
@@ -90,10 +90,16 @@ class SolidityImportSerializer(serializers.Serializer):
             import_results.extend(Signature.import_from_solidity_file(
                 validated_data['source_file'],
             ))
+            import_results.extend(EventSignature.import_from_solidity_file(
+                validated_data['source_file']
+            ))
 
         if validated_data.get('source_code'):
             import_results.extend(Signature.import_from_solidity_code(
                 validated_data['source_code'],
+            ))
+            import_results.extend(EventSignature.import_from_solidity_code(
+                validated_data['source_code']
             ))
 
         num_processed = len(import_results)

--- a/func_sig_registry/registry/serializers.py
+++ b/func_sig_registry/registry/serializers.py
@@ -2,9 +2,11 @@ import json
 
 from rest_framework import serializers
 
+from func_sig_registry.utils.import_statistics import (
+    retrieve_stats_from_import_results,
+)
 from func_sig_registry.utils.abi import (
     is_valid_contract_abi,
-    retrieve_stats_from_import_results,
 )
 from func_sig_registry.utils.events_solidity import (
     normalize_event_signature,

--- a/func_sig_registry/registry/serializers.py
+++ b/func_sig_registry/registry/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from func_sig_registry.utils.import_statistics import (
     retrieve_stats_from_import_results,
+    empty_import_stats,
 )
 from func_sig_registry.utils.abi import (
     is_valid_contract_abi,
@@ -84,37 +85,36 @@ class SolidityImportSerializer(serializers.Serializer):
     num_processed = serializers.IntegerField(read_only=True)
     num_imported = serializers.IntegerField(read_only=True)
     num_duplicates = serializers.IntegerField(read_only=True)
+    num_ignored = serializers.IntegerField(read_only=True)
 
     def create(self, validated_data):
-        import_results = []
+        stats_function = empty_import_stats()
+        stats_event = empty_import_stats()
 
         if validated_data.get('source_file'):
-            import_results.extend(Signature.import_from_solidity_file(
-                validated_data['source_file'],
-            ))
-            import_results.extend(EventSignature.import_from_solidity_file(
-                validated_data['source_file']
-            ))
-
+            stats_function = retrieve_stats_from_import_results(
+                Signature.import_from_solidity_file(validated_data['source_file'])
+            )
+            stats_event = retrieve_stats_from_import_results(
+                EventSignature.import_from_solidity_file(validated_data['source_file'])
+            )
         if validated_data.get('source_code'):
-            import_results.extend(Signature.import_from_solidity_code(
-                validated_data['source_code'],
-            ))
-            import_results.extend(EventSignature.import_from_solidity_code(
-                validated_data['source_code']
-            ))
+            stats_function = retrieve_stats_from_import_results(
+                Signature.import_from_solidity_code(validated_data['source_code'])
+            )
+            stats_event = retrieve_stats_from_import_results(
+                EventSignature.import_from_solidity_code(validated_data['source_code'])
+            )
 
-        num_processed = len(import_results)
-        if num_processed == 0:
-            num_imported = 0
-            num_duplicates = 0
-        else:
-            num_imported = sum(tuple(zip(*import_results))[1])
-            num_duplicates = num_processed - num_imported
         return {
-            'num_processed': num_processed,
-            'num_imported': num_imported,
-            'num_duplicates': num_duplicates,
+            'num_processed':
+                stats_function.num_processed + stats_event.num_processed,
+            'num_imported':
+                stats_function.num_imported + stats_event.num_imported,
+            'num_duplicates':
+                stats_function.num_duplicates + stats_event.num_duplicates,
+            'num_ignored':
+                stats_function.num_ignored + stats_event.num_ignored,
         }
 
 

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -119,9 +119,8 @@ class SolidityImportView(generics.GenericAPIView):
         results = serializer.save()
         import_results = []
         for file_obj in results['source_files']:
-            code = force_text(file_obj.read())
-            import_results.extend(Signature.import_from_solidity_code(code))
-            import_results.extend(EventSignature.import_from_solidity_code(code))
+            import_results.extend(Signature.import_from_solidity_file(file_obj))
+            import_results.extend(EventSignature.import_from_solidity_file(file_obj))
         num_processed = len(import_results)
         if num_processed == 0:
             num_imported = 0

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -139,7 +139,7 @@ class SolidityImportView(generics.GenericAPIView):
             messages.success(
                 self.request._request,
                 "Found {0} function and event signatures.  Imported {1}, Ignored {2}, Skipped {3} duplicates.".format(
-                    num_processed, num_imported, num_ignored, num_ignored, num_duplicates,
+                    num_processed, num_imported, num_ignored, num_duplicates,
                 ),
             )
         return redirect('signature-list')

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -13,7 +13,6 @@ from django_tables2 import SingleTableView
 
 from func_sig_registry.utils.encoding import (
     remove_0x_prefix,
-    force_text,
 )
 
 from .models import (

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -15,7 +15,10 @@ from func_sig_registry.utils.encoding import (
     remove_0x_prefix,
 )
 
-from .models import Signature
+from .models import (
+    Signature,
+    EventSignature,
+)
 from .tables import SignatureTable
 from .forms import (
     SignatureForm,

--- a/func_sig_registry/utils/abi.py
+++ b/func_sig_registry/utils/abi.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from typing import (
     Any,
     Dict,
@@ -139,34 +138,4 @@ def event_definition_to_text_signature(abi: Dict[str, Any]) -> str:
             [f"{collapse_if_tuple(abi_input)}{' indexed' if abi_input['indexed'] else ''}"
                 for abi_input in abi.get('inputs', [])]
         ),
-    )
-
-
-ImportStats = namedtuple('ImportStats', ['num_processed', 'num_imported',
-                                         'num_duplicates', 'num_ignored'])
-
-
-def retrieve_stats_from_import_results(raw_import_results):
-    num_processed = len(raw_import_results)
-
-    import_results = [
-        result
-        for result in raw_import_results
-        if result is not None
-    ]
-
-    num_ignored = num_processed - len(import_results)
-
-    if len(import_results) == 0:
-        num_imported = 0
-        num_duplicates = 0
-    else:
-        num_imported = sum(tuple(zip(*import_results))[1])
-        num_duplicates = len(import_results) - num_imported
-
-    return ImportStats(
-        num_processed=num_processed,
-        num_imported=num_imported,
-        num_duplicates=num_duplicates,
-        num_ignored=num_ignored,
     )

--- a/func_sig_registry/utils/import_statistics.py
+++ b/func_sig_registry/utils/import_statistics.py
@@ -3,6 +3,13 @@ from collections import namedtuple
 ImportStats = namedtuple('ImportStats', ['num_processed', 'num_imported',
                                          'num_duplicates', 'num_ignored'])
 
+def empty_import_stats():
+    return ImportStats(
+        num_processed=0,
+        num_imported=0,
+        num_duplicates=0,
+        num_ignored=0,
+    )
 
 def retrieve_stats_from_import_results(raw_import_results):
     num_processed = len(raw_import_results)

--- a/func_sig_registry/utils/import_statistics.py
+++ b/func_sig_registry/utils/import_statistics.py
@@ -1,0 +1,30 @@
+from collections import namedtuple
+
+ImportStats = namedtuple('ImportStats', ['num_processed', 'num_imported',
+                                         'num_duplicates', 'num_ignored'])
+
+
+def retrieve_stats_from_import_results(raw_import_results):
+    num_processed = len(raw_import_results)
+
+    import_results = [
+        result
+        for result in raw_import_results
+        if result is not None
+    ]
+
+    num_ignored = num_processed - len(import_results)
+
+    if len(import_results) == 0:
+        num_imported = 0
+        num_duplicates = 0
+    else:
+        num_imported = sum(tuple(zip(*import_results))[1])
+        num_duplicates = len(import_results) - num_imported
+
+    return ImportStats(
+        num_processed=num_processed,
+        num_imported=num_imported,
+        num_duplicates=num_duplicates,
+        num_ignored=num_ignored,
+    )

--- a/tests/web/api/test_solidity_code_and_file_import.py
+++ b/tests/web/api/test_solidity_code_and_file_import.py
@@ -1,0 +1,40 @@
+from io import BytesIO
+from rest_framework import status
+from django.core.urlresolvers import reverse
+
+
+CODE = """
+contract Foo {
+    function foo_1(uint a) {
+    }
+
+    event foo_2(uint a);
+}
+"""
+
+FILE = b"""
+contract Bar {
+    function bar_1(uint a) {
+
+    }
+
+    event bar_2(uint a);
+}
+"""
+
+
+def test_importing_solidity_source_code(api_client, factories):
+    import_url = reverse('api:import-solidity')
+    source_file = BytesIO(FILE)
+
+    response = api_client.post(import_url, {
+        'source_code': CODE,
+        'source_fuke': source_file,
+    }, format='multipart')
+
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.data
+    assert data['num_processed'] == 4
+    assert data['num_imported'] == 4
+    assert data['num_duplicates'] == 0
+    assert data['num_ignored'] == 0

--- a/tests/web/api/test_solidity_code_and_file_import.py
+++ b/tests/web/api/test_solidity_code_and_file_import.py
@@ -29,7 +29,7 @@ def test_importing_solidity_source_code(api_client, factories):
 
     response = api_client.post(import_url, {
         'source_code': CODE,
-        'source_fuke': source_file,
+        'source_file': source_file,
     }, format='multipart')
 
     assert response.status_code == status.HTTP_201_CREATED

--- a/tests/web/api/test_solidity_file_import.py
+++ b/tests/web/api/test_solidity_file_import.py
@@ -49,11 +49,61 @@ contract Foo {
 
     // functions with non-standard type args ignored
     function foo_11(bar a, ufixed b){}
+
+    // function signature expected stats: 
+    // processed: 9
+    // imported: 7
+    // duplicated: 2
+
+    // empty event
+    event bar_1();
+
+    // event with one argument (normalized)
+    event bar_2(uint256 a);
+
+    // event with one argument (not normalized)
+    event bar_3(uint a);
+
+    // event with indexed argument
+    event bar_4(address indexed a);
+
+    // event with dynamic type argument
+    event bar_5(bytes[32] a);
+
+    // event with dynamic and indexex argument
+    event bar_6(bytes[32] indexed a);
+
+    // werid spacing
+    event bar_7  ( address from,address to ) ;
+
+    // weird spacing and mutlitline (2)
+    event bar_8 (
+        uint a,
+        uint b,
+        uint c
+    );
+
+    // commented event
+    // event bar_9(uint8 b);
+
+    // invalid event, wrong argument type (ignored)
+    event bar_10(function a);
+
+    // invalid, wrong argument delimeter (ignored)
+    event bar_10(uint a; uint b);
 }
 """
 
 
 def test_importing_solidity_source_file(api_client, factories):
+    # function signature import expected stats:
+    # processed: 9 | imported: 7 | duplicated: 2
+    #
+    # event signature import expected stats:
+    # processed: 9 | imported: 9 | duplicated: 0
+    # 
+    # total:
+    # processed: 18 | imported 16 | duplicated: 2
     factories.SignatureFactory(text_signature='foo_7(int256)')
     factories.SignatureFactory(text_signature='foo_6(int256)')
 
@@ -64,6 +114,6 @@ def test_importing_solidity_source_file(api_client, factories):
 
     assert response.status_code == status.HTTP_201_CREATED
     data = response.data
-    assert data['num_processed'] == 9
-    assert data['num_imported'] == 7
+    assert data['num_processed'] == 18
+    assert data['num_imported'] == 16
     assert data['num_duplicates'] == 2

--- a/tests/web/api/test_solidity_file_import.py
+++ b/tests/web/api/test_solidity_file_import.py
@@ -50,11 +50,6 @@ contract Foo {
     // functions with non-standard type args ignored
     function foo_11(bar a, ufixed b){}
 
-    // function signature expected stats: 
-    // processed: 9
-    // imported: 7
-    // duplicated: 2
-
     // empty event
     event bar_1();
 

--- a/tests/web/api/test_solidity_source_import.py
+++ b/tests/web/api/test_solidity_source_import.py
@@ -34,11 +34,56 @@ contract Foo {
 
     // commented out
     // function foo_8(address x) {}
+
+    // empty event
+    event bar_1();
+
+    // event with one argument (normalized)
+    event bar_2(uint256 a);
+
+    // event with one argument (not normalized)
+    event bar_3(uint a);
+
+    // event with indexed argument
+    event bar_4(address indexed a);
+
+    // event with dynamic type argument
+    event bar_5(bytes[32] a);
+
+    // event with dynamic and indexex argument
+    event bar_6(bytes[32] indexed a);
+
+    // werid spacing
+    event bar_7  ( address from,address to ) ;
+
+    // weird spacing and mutlitline (2)
+    event bar_8 (
+        uint a,
+        uint b,
+        uint c
+    );
+
+    // commented event
+    // event bar_9(uint8 b);
+
+    // invalid event, wrong argument type (ignored)
+    event bar_10(function a);
+
+    // invalid, wrong argument delimeter (ignored)
+    event bar_10(uint a; uint b);
 }
 """
 
 
 def test_importing_solidity_source_code(api_client, factories):
+    # function signature import expected stats:
+    # processed: 8 | imported: 6 | duplicated: 2
+    #
+    # event signature import expected stats:
+    # processed: 9 | imported: 9 | duplicated: 0
+    # 
+    # total:
+    # processed: 17 | imported 15 | duplicated: 2
     factories.SignatureFactory(text_signature='foo_7(int256)')
     factories.SignatureFactory(text_signature='foo_6(int256)')
 
@@ -48,6 +93,6 @@ def test_importing_solidity_source_code(api_client, factories):
 
     assert response.status_code == status.HTTP_201_CREATED
     data = response.data
-    assert data['num_processed'] == 8
-    assert data['num_imported'] == 6
+    assert data['num_processed'] == 17
+    assert data['num_imported'] == 15
     assert data['num_duplicates'] == 2

--- a/tests/web/api/test_solidity_source_import.py
+++ b/tests/web/api/test_solidity_source_import.py
@@ -35,6 +35,9 @@ contract Foo {
     // commented out
     // function foo_8(address x) {}
 
+    // inavlid function name (ignored)
+    function function(uint a) {}
+
     // empty event
     event bar_1();
 
@@ -66,26 +69,33 @@ contract Foo {
     // commented event
     // event bar_9(uint8 b);
 
-    // invalid event, wrong argument type (ignored)
+    // invalid event, wrong argument type (not processed)
     event bar_10(function a);
 
-    // invalid, wrong argument delimeter (ignored)
-    event bar_10(uint a; uint b);
+    // invalid, wrong argument delimeter (not processed)
+    event bar_11(uint a; uint b);
+
+    // duplicate event signature (duplicated)
+    event bar_12(uint a, uint b);
+
+    // invalid event name
+    event event(uint a);
 }
 """
 
 
 def test_importing_solidity_source_code(api_client, factories):
     # function signature import expected stats:
-    # processed: 8 | imported: 6 | duplicated: 2
+    # processed: 9 | imported: 6 | duplicated: 2 | ignored: 1
     #
     # event signature import expected stats:
-    # processed: 9 | imported: 9 | duplicated: 0
+    # processed: 11 | imported: 9 | duplicated: 1 | ignored: 1
     # 
     # total:
-    # processed: 17 | imported 15 | duplicated: 2
+    # processed: 20 | imported 15 | duplicated: 3 | ignored: 2
     factories.SignatureFactory(text_signature='foo_7(int256)')
     factories.SignatureFactory(text_signature='foo_6(int256)')
+    factories.EventSignatureFactory(text_signature='bar_12(uint256,uint256)')
 
     import_url = reverse('api:import-solidity')
 
@@ -93,6 +103,7 @@ def test_importing_solidity_source_code(api_client, factories):
 
     assert response.status_code == status.HTTP_201_CREATED
     data = response.data
-    assert data['num_processed'] == 17
+    assert data['num_processed'] == 20
     assert data['num_imported'] == 15
-    assert data['num_duplicates'] == 2
+    assert data['num_duplicates'] == 3
+    assert data['num_ignored'] == 2

--- a/tests/web/api/test_solidity_source_import.py
+++ b/tests/web/api/test_solidity_source_import.py
@@ -90,7 +90,7 @@ def test_importing_solidity_source_code(api_client, factories):
     #
     # event signature import expected stats:
     # processed: 11 | imported: 9 | duplicated: 1 | ignored: 1
-    # 
+    #
     # total:
     # processed: 20 | imported 15 | duplicated: 3 | ignored: 2
     factories.SignatureFactory(text_signature='foo_7(int256)')

--- a/tests/web/utility/test_retrieve_stats_from_import_results.py
+++ b/tests/web/utility/test_retrieve_stats_from_import_results.py
@@ -1,6 +1,6 @@
 import pytest
 
-from func_sig_registry.utils.abi import (
+from func_sig_registry.utils.import_statistics import (
     retrieve_stats_from_import_results,
 )
 


### PR DESCRIPTION
### What is wrong?

Currently, the application has support for event signature extraction from solidity source code. However, it is not being extracted during the actual code submission. 

### How can it be fixed

- [x] Change the current code submission API view, so it will call the right method from the EventSignature model.
- [x] After extraction output the correct message, the one which has information about how many function signatures and event signatures were extracted/ignored/duplicated.
- [x] Cover new changes with unit tests. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.globalcitizen.org/thumbnails/98/e4/98e491cb-0f2d-4726-b997-441cfb66d5b5/adorable-polar-bears.png__1500x670_q85_crop_subsampling-2.png)
