### PR TITLE
Browsable page for Event Signatures

### DIFF
--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -28,6 +28,12 @@ class SignatureSearchForm(serializers.Serializer):
     )
 
 
+class EventSignatureSearchForm(serializers.Serializer):
+    bytes_signature = serializers.CharField(
+        style={'placeholder': '0x7805862f689e2f13df9f062ff482ad3ad112aca9e0847911ed832e158c525b33'},
+    )
+
+
 class SignatureForm(serializers.ModelSerializer):
     bytes4_signature = serializers.CharField(read_only=True,
                                              source='bytes_signature.get_hex_display')

--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -30,7 +30,7 @@ class SignatureSearchForm(serializers.Serializer):
 
 class EventSignatureSearchForm(serializers.Serializer):
     bytes_signature = serializers.CharField(
-        style={'placeholder': '0x7805862f689e2f13df9f062ff482ad3ad112aca9e0847911ed832e158c525b33'},
+        style={'placeholder': '0x82ff462f689e2f73df9fd8306282ad3ad112aca9e0847911e8051e158c525b33'},
     )
 
 

--- a/func_sig_registry/registry/tables.py
+++ b/func_sig_registry/registry/tables.py
@@ -29,8 +29,8 @@ class EventSignatureTable(tables.Table):
         model = EventSignature
         fields = (
             'id',
-            'text_signature'
-            'hex_signature'
+            'text_signature',
+            'hex_signature',
         )
         template = 'partials/table.html'
         attrs = {

--- a/func_sig_registry/registry/tables.py
+++ b/func_sig_registry/registry/tables.py
@@ -25,6 +25,9 @@ class SignatureTable(tables.Table):
 
 
 class EventSignatureTable(tables.Table):
+    hex_signature = tables.TemplateColumn(
+        '<code>{{ record.get_hex_display }}</code>',
+    )
     class Meta:
         model = EventSignature
         fields = (

--- a/func_sig_registry/registry/tables.py
+++ b/func_sig_registry/registry/tables.py
@@ -28,6 +28,7 @@ class EventSignatureTable(tables.Table):
     hex_signature = tables.TemplateColumn(
         '<code>{{ record.get_hex_display }}</code>',
     )
+
     class Meta:
         model = EventSignature
         fields = (

--- a/func_sig_registry/registry/tables.py
+++ b/func_sig_registry/registry/tables.py
@@ -2,6 +2,7 @@ import django_tables2 as tables
 
 from .models import (
     Signature,
+    EventSignature,
 )
 
 
@@ -16,6 +17,20 @@ class SignatureTable(tables.Table):
             'id',
             'text_signature',
             'bytes_signature',
+        )
+        template = 'partials/table.html'
+        attrs = {
+            'class': 'table table-striped table-bordered',
+        }
+
+
+class EventSignatureTable(tables.Table):
+    class Meta:
+        model = EventSignature
+        fields = (
+            'id',
+            'text_signature'
+            'hex_signature'
         )
         template = 'partials/table.html'
         attrs = {

--- a/func_sig_registry/registry/templates/registry/eventsignature_list.html
+++ b/func_sig_registry/registry/templates/registry/eventsignature_list.html
@@ -1,0 +1,12 @@
+{% extends 'layout_full.html' %}
+{% load render_table from django_tables2 %}
+{% load rest_framework %}
+
+
+{% block content %}
+  <div class="row">
+    <div class="col-md-12">
+      {% render_table table %}
+    </div>
+  </div>
+{% endblock %}

--- a/func_sig_registry/registry/templates/registry/eventsignature_list.html
+++ b/func_sig_registry/registry/templates/registry/eventsignature_list.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-md-12">
       <form class="form-inline" action="{% url 'event-signature-list' %}" method="get" novalidate>
-        <label for="bytes4_signature">Search Signatures</label>
+        <label for="bytes_signature">Search Signatures</label>
         {% render_form serializer template_pack='rest_framework/inline' %}
         <button type="submit" class="btn btn-default">Search</button>
       </form>

--- a/func_sig_registry/registry/templates/registry/eventsignature_list.html
+++ b/func_sig_registry/registry/templates/registry/eventsignature_list.html
@@ -6,6 +6,11 @@
 {% block content %}
   <div class="row">
     <div class="col-md-12">
+      <form class="form-inline" action="{% url 'event-signature-list' %}" method="get" novalidate>
+        <label for="bytes4_signature">Search Signatures</label>
+        {% render_form serializer template_pack='rest_framework/inline' %}
+        <button type="submit" class="btn btn-default">Search</button>
+      </form>
       {% render_table table %}
     </div>
   </div>

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -72,12 +72,12 @@ class SignatureListView(SingleTableView, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(SignatureListView, self).get_context_data(**kwargs)
-        if self.request.GET.get('bytes4_signature'):
-            serializer = SignatureSearchForm(data=self.request.GET)
-            serializer.is_valid()
-        else:
-            serializer = SignatureSearchForm()
-        context['serializer'] = serializer
+        # if self.request.GET.get('bytes4_signature'):
+        #     serializer = SignatureSearchForm(data=self.request.GET)
+        #     serializer.is_valid()
+        # else:
+        #     serializer = SignatureSearchForm()
+        context['serializer'] = SignatureSearchForm()
         return context
 
 
@@ -112,7 +112,7 @@ class EventSignatureListView(SingleTableView, ListView):
             serializer.is_valid()
         else:
             serializer = EventSignatureSearchForm()
-        context['serializer'] = EventSignatureSearchForm()
+        context['serializer'] = serializer
         return context
 
 

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -101,13 +101,13 @@ class EventSignatureListView(SingleTableView, ListView):
                 )
             else:
                 return queryset.filter(
-                    hex_signature__icontains=unprefixed_hex_signature,  #NOQA
+                    hex_signature__icontains=unprefixed_hex_signature,  # NOQA
                 )
         return queryset
 
     def get_context_data(self, **kwargs):
         context = super(EventSignatureListView, self).get_context_data(**kwargs)
-        if self.request.GET.get('hex_signature'):
+        if self.request.GET.get('bytes_signature'):
             serializer = EventSignatureSearchForm(data=self.request.GET)
             serializer.is_valid()
         else:

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -72,12 +72,12 @@ class SignatureListView(SingleTableView, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(SignatureListView, self).get_context_data(**kwargs)
-        # if self.request.GET.get('bytes4_signature'):
-        #     serializer = SignatureSearchForm(data=self.request.GET)
-        #     serializer.is_valid()
-        # else:
-        #     serializer = SignatureSearchForm()
-        context['serializer'] = SignatureSearchForm()
+        if self.request.GET.get('bytes4_signature'):
+            serializer = SignatureSearchForm(data=self.request.GET)
+            serializer.is_valid()
+        else:
+            serializer = SignatureSearchForm()
+        context['serializer'] = serializer
         return context
 
 

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -22,7 +22,10 @@ from .models import (
     Signature,
     EventSignature,
 )
-from .tables import SignatureTable
+from .tables import (
+    SignatureTable,
+    EventSignatureTable,
+)
 from .forms import (
     SignatureForm,
     SolidityImportForm,
@@ -75,6 +78,18 @@ class SignatureListView(SingleTableView, ListView):
             serializer = SignatureSearchForm()
         context['serializer'] = serializer
         return context
+
+
+class EventSignatureListView(SingleTableView, ListView):
+    model = EventSignature
+    table_class = EventSignatureTable
+    table_pagination = {
+        'per_page': 10
+    }
+
+    def get_queryset(self):
+        queryset = super(EventSignatureListView, self).get_queryset()
+        return queryset
 
 
 class SignatureCreateView(generics.CreateAPIView):

--- a/func_sig_registry/templates/base.html
+++ b/func_sig_registry/templates/base.html
@@ -16,7 +16,8 @@
         </div><!-- /.navbar-header -->	
         <div>
 					<ul class="nav navbar-nav">
-						<li><a href="{% url 'signature-list' %}">Browse Signatures</a></li>
+            <li><a href="{% url 'signature-list' %}">Browse Function Signatures</a></li>
+            <li><a href="{% url 'event-signature-list' %}">Browse Event Signatures</a></li>
 						<li><a href="{% url 'signature-create' %}">Submit Signatures</a></li>
 						<li><a href="{% url 'import-abi' %}">Submit ABI</a></li>
 						<li><a href="{% url 'import-solidity' %}">Submit Solidity Source File</a></li>

--- a/func_sig_registry/templates/base.html
+++ b/func_sig_registry/templates/base.html
@@ -16,8 +16,8 @@
         </div><!-- /.navbar-header -->	
         <div>
 					<ul class="nav navbar-nav">
-            <li><a href="{% url 'signature-list' %}">Browse Function Signatures</a></li>
-            <li><a href="{% url 'event-signature-list' %}">Browse Event Signatures</a></li>
+						<li><a href="{% url 'signature-list' %}">Browse Function Signatures</a></li>
+						<li><a href="{% url 'event-signature-list' %}">Browse Event Signatures</a></li>
 						<li><a href="{% url 'signature-create' %}">Submit Signatures</a></li>
 						<li><a href="{% url 'import-abi' %}">Submit ABI</a></li>
 						<li><a href="{% url 'import-solidity' %}">Submit Solidity Source File</a></li>

--- a/func_sig_registry/templates/base.html
+++ b/func_sig_registry/templates/base.html
@@ -16,8 +16,8 @@
         </div><!-- /.navbar-header -->	
         <div>
 					<ul class="nav navbar-nav">
-						<li><a href="{% url 'signature-list' %}">Browse Function Signatures</a></li>
-						<li><a href="{% url 'event-signature-list' %}">Browse Event Signatures</a></li>
+						<li><a href="{% url 'signature-list' %}">Function Signatures</a></li>
+						<li><a href="{% url 'event-signature-list' %}">Event Signatures</a></li>
 						<li><a href="{% url 'signature-create' %}">Submit Signatures</a></li>
 						<li><a href="{% url 'import-abi' %}">Submit ABI</a></li>
 						<li><a href="{% url 'import-solidity' %}">Submit Solidity Source File</a></li>

--- a/func_sig_registry/urls.py
+++ b/func_sig_registry/urls.py
@@ -26,6 +26,7 @@ from func_sig_registry.registry.views import (
     SignatureCreateView,
     SolidityImportView,
     ImportContractABIView,
+    EventSignatureListView,
 )
 
 
@@ -37,6 +38,7 @@ def lets_encrypt(request):
 urlpatterns = [
     url(r'^$', SiteIndexView.as_view(), name='site-index'),
     url(r'^signatures/$', SignatureListView.as_view(), name='signature-list'),
+    url(r'^event-signatures/$', EventSignatureListView.as_view(), name='event-signature-list'),
     url(r'^submit/$', SignatureCreateView.as_view(), name='signature-create'),
     url(r'^import-solidity/$', SolidityImportView.as_view(), name='import-solidity'),
     url(r'^import-abi/$', ImportContractABIView.as_view(), name='import-abi'),

--- a/tests/web/api/test_solidity_file_import.py
+++ b/tests/web/api/test_solidity_file_import.py
@@ -105,7 +105,7 @@ def test_importing_solidity_source_file(api_client, factories):
     #
     # event signature import expected stats:
     # processed: 11 | imported: 9 | duplicated: 1 | ignored: 1
-    # 
+    #
     # total:
     # processed: 21 | imported 16 | duplicated: 3 | ignored: 2
     factories.SignatureFactory(text_signature='foo_7(int256)')

--- a/tests/web/registry/test_browsable_event_signatures.py
+++ b/tests/web/registry/test_browsable_event_signatures.py
@@ -3,13 +3,26 @@ import string
 
 from django.test import Client
 
-EVENT_SIGNATURE_HTML = '<td class="text_signature">a(uint256)</td>'
+EVENT_TEXT_SIGNATURE = 'a(uint256)'
+EVENT_HEX_SIGNATURE = '0xf0fdf83467af68171df09204c0b00056c1e4c80e368b3fff732778b858f7966d'
+
+EVENT_SIGNATURE_HTML = f'<td class="text_signature">{EVENT_TEXT_SIGNATURE}</td>'
 EVENT_SIGNATURE_HEX_HTML = ''.join([
     '<td class="hex_signature">',
     '<code>',
-    '0xf0fdf83467af68171df09204c0b00056c1e4c80e368b3fff732778b858f7966d',
+    EVENT_HEX_SIGNATURE,
     '</code>',
     '</td>',
+])
+
+SEARCH_INPUT_HTML_WITH_VALUE = ' '.join([
+    '<input name="bytes_signature" class="form-control" type="text"',
+    'placeholder="0x82ff462f689e2f73df9fd8306282ad3ad112aca9e0847911e8051e158c525b33"',
+    f'value="{EVENT_HEX_SIGNATURE}">',
+])
+SEARCH_INPUT_HTML_EMPTY = ' '.join([
+    '<input name="bytes_signature" class="form-control" type="text"',
+    'placeholder="0x82ff462f689e2f73df9fd8306282ad3ad112aca9e0847911e8051e158c525b33" >'
 ])
 
 
@@ -31,8 +44,27 @@ def test_browsable_event_signature_search(factories):
 
     client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
 
-    # requesting prefix
-    response = client.get('/event-signatures/', {'bytes_signature': '0xf0fdf83467af68171df09204c0'})
+    response = client.get('/event-signatures/',
+                          {'bytes_signature': EVENT_HEX_SIGNATURE})
 
     assert(b'a(uint256)' in response.content)
     assert(b'b(uint256)' not in response.content)
+
+
+@pytest.mark.django_db
+def test_event_signature_list_get_context_data():
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    response = client.get('/event-signatures/',
+                          {'bytes_signature': EVENT_HEX_SIGNATURE})
+
+    assert(str.encode(SEARCH_INPUT_HTML_WITH_VALUE) in response.content)
+
+
+@pytest.mark.django_db
+def test_event_signature_list_get_context_data_empty():
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    response = client.get('/event-signatures/')
+
+    assert(str.encode(SEARCH_INPUT_HTML_EMPTY) in response.content)

--- a/tests/web/registry/test_browsable_event_signatures.py
+++ b/tests/web/registry/test_browsable_event_signatures.py
@@ -1,0 +1,38 @@
+import pytest
+import string
+
+from django.test import Client
+
+EVENT_SIGNATURE_HTML = '<td class="text_signature">a(uint256)</td>'
+EVENT_SIGNATURE_HEX_HTML = ''.join([
+    '<td class="hex_signature">',
+    '<code>',
+    '0xf0fdf83467af68171df09204c0b00056c1e4c80e368b3fff732778b858f7966d',
+    '</code>',
+    '</td>',
+])
+
+
+@pytest.mark.django_db
+def test_browsable_event_signature_html(factories):
+    factories.EventSignatureFactory(text_signature='a(uint256)')
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+    response = client.get('/event-signatures/')
+
+    assert(str.encode(EVENT_SIGNATURE_HTML) in response.content)
+    assert(str.encode(EVENT_SIGNATURE_HEX_HTML) in response.content)
+
+
+@pytest.mark.django_db
+def test_browsable_event_signature_search(factories):
+    factories.EventSignatureFactory(text_signature='a(uint256)')
+    factories.EventSignatureFactory(text_signature='b(uint256)')
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    # requesting prefix
+    response = client.get('/event-signatures/', {'bytes_signature': '0xf0fdf83467af68171df09204c0'})
+
+    assert(b'a(uint256)' in response.content)
+    assert(b'b(uint256)' not in response.content)

--- a/tests/web/registry/test_browsable_function_signatures.py
+++ b/tests/web/registry/test_browsable_function_signatures.py
@@ -1,0 +1,58 @@
+import pytest
+import string
+
+from django.test import Client
+
+SEARCH_INPUT_WITH_DATA = ' '.join([
+    '<input name="bytes4_signature" class="form-control" type="text"',
+    'placeholder="0x70a08231" value="0xf0fdf834">',
+])
+SEARCH_INPUT_EMPTY = ' '.join([
+    '<input name="bytes4_signature" class="form-control" type="text"',
+    'placeholder="0x70a08231" >',
+])
+
+@pytest.mark.django_db
+def test_browsable_function_signature_table(factories):
+    factories.SignatureFactory(text_signature='a(uint256)')
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+    response = client.get('/signatures/')
+
+    assert(b'a(uint256)' in response.content)
+    assert(b'0xf0fdf834' in response.content)
+
+
+@pytest.mark.django_db
+def test_browsable_function_signature_search(factories):
+    factories.SignatureFactory(text_signature='a(uint256)')
+    factories.SignatureFactory(text_signature='b(uint256)')
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    response = client.get('/signatures/',
+                          {'bytes4_signature': '0xf0fdf834'})
+
+    assert(b'a(uint256)' in response.content)
+    assert(b'b(uint256)' not in response.content)
+
+
+@pytest.mark.django_db
+def test_function_signature_list_get_context_data():
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    response = client.get('/signatures/',
+                          {'bytes4_signature': '0xf0fdf834'})
+
+    assert(str.encode(SEARCH_INPUT_WITH_DATA) in response.content)
+
+
+@pytest.mark.django_db
+def test_function_signature_list_get_context_data_empty():
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    response = client.get('/signatures/')
+
+    print(response.content.decode('utf-8'))
+
+    assert(str.encode(SEARCH_INPUT_EMPTY) in response.content)


### PR DESCRIPTION
### What was wrong?

Current implementation accepts, stores, and shares event signatures via HTTP requests, however, they also should be browsable.

### How was it fixed?

Implementing the necessary table and serializer class should solve this issue. 

### To-Do

- [x] Implement table class
- [x] Implement serializer class
- [x] Add new HTML template
- [x] Add search feature
- [x] Write tests for event signature UI using Django Client
- [x] Write tests for function signature UI using Django Client

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.loudwallpapers.com/wp-content/uploads/2019/10/cute-german-spitz-wallpaper-1920x1280p.jpg)
