### PR TITLE
Creating both signatures using single form

### DIFF
--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -21,6 +21,10 @@ from func_sig_registry.utils.solidity import (
     normalize_function_signature,
 )
 
+from func_sig_registry.utils.events_solidity import {
+    normalize_event_signature,
+}
+
 
 class SignatureSearchForm(serializers.Serializer):
     bytes4_signature = serializers.CharField(
@@ -45,6 +49,37 @@ class SignatureForm(serializers.ModelSerializer):
 
     def validate_text_signature(self, value):
         return normalize_function_signature(value)
+
+
+class AllSignatureCreateForm(serializers.Serializer):
+    function_text_signature = serializers.CharField(read_only=True)
+    event_text_signature = serializers.CharField(read_only=True)
+
+    def create(self, validated_data):
+        message = ''
+        if 'function_text_signature' in validated_data:
+            function_signature = Signature.import_from_raw_text_signature(
+                validated_data['function_text_signature'],
+                )
+            message += 'Added function signature {0} for function {1}'.format(
+                function_signature.bytes_signature.get_hex_display(),
+                function_signature.text_signature,
+            )
+        if 'event_text_signature' in validated_data:
+            event_signature = EventSignature.import_from_raw_text_signature(
+                validated_data['event_text_signature'],
+            )
+            message += 'Added event signature {0} for event {1}'.format(
+                event_signature.get_hex_display(),
+                event_signature.text_signature,
+            )
+        return message
+
+    def validate_function_text_signature(self, value):
+        return normalize_function_signature(value)
+    
+    def validate_event_text_signate(self, value):
+        return normalize_event_signature(value)
 
 
 class MultiFileField(serializers.FileField):

--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -56,24 +56,24 @@ class AllSignatureCreateForm(serializers.Serializer):
     event_text_signature = serializers.CharField(read_only=True)
 
     def create(self, validated_data):
-        message = ''
+        message_parts = []
         if 'function_text_signature' in validated_data:
             function_signature = Signature.import_from_raw_text_signature(
                 validated_data['function_text_signature'],
                 )
-            message += 'Added function signature {0} for function {1}'.format(
+            message_parts.append('Added function signature {0} for function {1}.'.format(
                 function_signature.bytes_signature.get_hex_display(),
                 function_signature.text_signature,
-            )
+            ))
         if 'event_text_signature' in validated_data:
             event_signature = EventSignature.import_from_raw_text_signature(
                 validated_data['event_text_signature'],
             )
-            message += 'Added event signature {0} for event {1}'.format(
+            message_parts.append('Added event signature {0} for event {1}.'.format(
                 event_signature.get_hex_display(),
                 event_signature.text_signature,
-            )
-        return message
+            ))
+        return ' '.join(message_parts)
 
     def validate_function_text_signature(self, value):
         return normalize_function_signature(value)

--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -55,19 +55,19 @@ class AllSignatureCreateForm(serializers.Serializer):
     text_signature = serializers.CharField(write_only=True)
 
     def create(self, validated_data):
-        signatures = dict()
         if 'function_signature' in validated_data['text_signature']:
             function_signature = Signature.import_from_raw_text_signature(
                 validated_data['text_signature']['function_signature'],
             )
-            signatures.update({'function_signature': function_signature})
+        else:
+            function_signature = None
         if 'event_signature' in validated_data['text_signature']:
             event_signature = EventSignature.import_from_raw_text_signature(
                 validated_data['text_signature']['event_signature'],
             )
-            signatures.update({'event_signature': event_signature})
-        return (signatures.get('function_signature', None),
-                signatures.get('event_signature', None))
+        else:
+            event_signature = None
+        return (function_signature, event_signature)
 
     def validate_text_signature(self, value):
         validated_signatures = dict()

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -27,6 +27,7 @@ from .tables import (
     EventSignatureTable,
 )
 from .forms import (
+    AllSignatureCreateForm,
     SignatureForm,
     SolidityImportForm,
     SignatureSearchForm,
@@ -119,7 +120,7 @@ class EventSignatureListView(SingleTableView, ListView):
 class SignatureCreateView(generics.CreateAPIView):
     renderer_classes = [TemplateHTMLRenderer]
     template_name = 'registry/signature_create.html'
-    serializer_class = SignatureForm
+    serializer_class = AllSignatureCreateForm
 
     def get(self, *args, **kwargs):
         serializer = self.get_serializer()
@@ -131,13 +132,10 @@ class SignatureCreateView(generics.CreateAPIView):
         serializer = self.get_serializer(data=self.request.data)
         if not serializer.is_valid():
             return Response({'serializer': serializer})
-        signature = serializer.save()
+        results = serializer.save()
         messages.success(
             self.request._request,
-            "Added signature '{0}' for function '{1}'".format(
-                signature.bytes_signature.get_hex_display(),
-                signature.text_signature,
-            ),
+            results['response_message'],
         )
         return redirect('signature-list')
 

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -127,15 +127,13 @@ class SignatureCreateView(generics.CreateAPIView):
         if function_signature is not None:
             signature, created = function_signature
             if created:
-                message_parts.append('Added function signature {0} for function {1}.'.format(
-                    signature.bytes_signature.get_hex_display(),
+                message_parts.append('Added function signature {0}.'.format(
                     signature.text_signature,
                 ))
         if event_signature is not None:
             signature, created = event_signature
             if created:
-                message_parts.append('Added event signature {0} for event {1}.'.format(
-                    signature.get_hex_display(),
+                message_parts.append('Added event signature {0}.'.format(
                     signature.text_signature,
                 ))
         return ' '.join(message_parts)
@@ -156,7 +154,7 @@ class SignatureCreateView(generics.CreateAPIView):
                 ))
         return ' '.join(message_parts)
 
-    def any_signature_created(slef, function_signature, event_signature):
+    def any_signature_created(self, function_signature, event_signature):
         function_created = (function_signature is not None) and function_signature[1]
         event_created = (event_signature is not None) and event_signature[1]
         return function_created or event_created

--- a/tests/web/views/test_signature_submit.py
+++ b/tests/web/views/test_signature_submit.py
@@ -1,0 +1,83 @@
+from func_sig_registry.utils.events_solidity import normalize_event_signature
+import pytest
+
+from django.core.urlresolvers import reverse
+from django.test import Client
+from rest_framework import status
+
+from func_sig_registry.registry.models import (
+    Signature,
+    EventSignature,
+)
+
+
+@pytest.mark.django_db
+def test_function_and_event_signatures_created(api_client):
+    create_url = reverse('signature-create')
+
+    text_signature = 'foo(uint a)'
+    normalized_text_signature = 'foo(uint256)'
+
+    response = api_client.post(create_url, {'text_signature': text_signature}, follow=True)
+    assert(response.status_code == status.HTTP_200_OK)
+
+    function_signatures = Signature.objects.filter(text_signature=normalized_text_signature)
+    event_sginatures = EventSignature.objects.filter(text_signature=normalized_text_signature)
+
+    assert(len(function_signatures) == 1)
+    assert(len(event_sginatures) == 1)
+
+
+@pytest.mark.django_db
+def test_signatures_created_notification():
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    response = client.post('/submit/', {'text_signature': 'a(uint256)'}, follow=True)
+
+    assert(response.status_code == status.HTTP_200_OK)
+    assert(b'Added function signature a(uint256).' in response.content)
+    assert(b'Added event signature a(uint256).' in response.content)
+
+
+@pytest.mark.django_db
+def test_signature_duplicate_notification(factories):
+    factories.EventSignatureFactory(text_signature='a(uint256)')
+    factories.SignatureFactory(text_signature='a(uint256)')
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+
+    response = client.post('/submit/', {'text_signature': 'a(uint256)'}, follow=True)
+
+    assert(response.status_code == status.HTTP_200_OK)
+    assert(b'Function signature a(uint256) already exists.' in response.content)
+    assert(b'Event signature a(uint256) already exists.' in response.content)
+
+
+@pytest.mark.django_db
+def test_only_function_siganture_created_notification():
+    # Event signature should not be created because signature has too many indexed arguments.
+    function = 'foo(uint indexed a, uint indexed b, uint indexed c, uint indexed d, uint indexed e)'
+    normalized = 'foo(uint256,uint256,uint256,uint256,uint256)'
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+    response = client.post('/submit/', {'text_signature': function}, follow=True)
+
+    assert(response.status_code == status.HTTP_200_OK)
+    content = response.content.decode('utf-8')
+    assert('Added function signature {0}.'.format(normalized) in content)
+    assert('Added event signature {0}'.format(normalized) not in content)
+
+
+@pytest.mark.django_db
+def test_only_event_siganture_created_notification():
+    # Function signature should not be created because signature is anonymous.
+    signature = 'foo(uint a) anonymous'
+    normalized = 'foo(uint256)'
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+    response = client.post('/submit/', {'text_signature': signature}, follow=True)
+
+    assert(response.status_code == status.HTTP_200_OK)
+    content = response.content.decode('utf-8')
+    assert('Added event signature {0}'.format(normalized) in content)
+    assert('Added function signature {0}.'.format(normalized) not in content)


### PR DESCRIPTION
### What was wrong?

When signature is submitted through this [form](https://www.4byte.directory/submit/) it would parse and, if possible, create only function signature, but not an event signature. In practice, it should assume that input can be any of those signatures or even both.

### How was it fixed?

Implementing a serializer class that handles the creation of both objects and adding to existing view with some modifications should be enough. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history from the previous PR
- [x] Implement serializer class
- [x] Modify or create a different view to handle the request and integrate it with the serializer
- [x] Add tests

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/47/54/36/4754369482f45267d84f296f6ae9c5ac.jpg)
