### PR TITLE
Update Github Import Task for EventSignatures

### DIFF
--- a/func_sig_registry/registry/models.py
+++ b/func_sig_registry/registry/models.py
@@ -63,7 +63,7 @@ class Signature(models.Model):
         try:
             self.text_signature = normalize_function_signature(self.text_signature)
         except ValueError:
-            raise ValidationError('Unknown signature format')
+            raise ValidationError('Unknown function signature format')
 
     class Meta:
         unique_together = (
@@ -89,10 +89,10 @@ class Signature(models.Model):
         try:
             text_signature = normalize_function_signature(raw_function_signature)
         except ValueError:
-            logger.error("error signature: %s", raw_function_signature)
+            logger.error("error function signature: %s", raw_function_signature)
             return None
         else:
-            logger.info("importing signature: %s", text_signature)
+            logger.info("importing function signature: %s", text_signature)
             return cls.objects.get_or_create(
                 text_signature=text_signature,
             )
@@ -122,16 +122,6 @@ class Signature(models.Model):
             cls.import_from_raw_text_signature(raw_signature)
             for raw_signature in function_signatures
         ]
-
-    @classmethod
-    def import_from_github_repository(cls, login_or_name, repository, branch='master'):
-        for file_path in get_repository_solidity_files(login_or_name, repository, branch):
-            logger.info("importing solidity file: %s", file_path)
-            with open(file_path) as solidity_file:
-                try:
-                    cls.import_from_solidity_file(solidity_file)
-                except UnicodeDecodeError:
-                    logger.error('unicode error reading solidity file: %s', file_path)
 
 
 class BytesSignature(models.Model):
@@ -180,7 +170,7 @@ class EventSignature(models.Model):
             self.text_signature = normalize_event_signature(
                 self.text_signature)
         except ValueError:
-            raise ValidationError('Unknown signature format')
+            raise ValidationError('Unknown event signature format')
 
     class Meta:
         ordering = ('-created_at',)
@@ -207,10 +197,10 @@ class EventSignature(models.Model):
         try:
             text_signature = normalize_event_signature(raw_event_signature)
         except ValueError:
-            logger.error("error signature: %s", raw_event_signature)
+            logger.error("error event signature: %s", raw_event_signature)
             return None
         else:
-            logger.info("importing signature: %s", text_signature)
+            logger.info("importing event signature: %s", text_signature)
             return cls.objects.get_or_create(
                 text_signature=text_signature,
             )
@@ -240,13 +230,3 @@ class EventSignature(models.Model):
             cls.import_from_raw_text_signature(raw_signature)
             for raw_signature in event_signatures
         ]
-
-    @classmethod
-    def import_from_github_repository(cls, login_or_name, repository, branch='master'):
-        for file_path in get_repository_solidity_files(login_or_name, repository, branch):
-            logger.info("importing solidity file: %s", file_path)
-            with open(file_path) as solidity_file:
-                try:
-                    cls.import_from_solidity_file(solidity_file)
-                except UnicodeDecodeError:
-                    logger.error('unicode error reading solidity file: %s', file_path)

--- a/func_sig_registry/registry/tasks.py
+++ b/func_sig_registry/registry/tasks.py
@@ -3,8 +3,13 @@ import sys
 
 from huey.contrib.djhuey import db_task
 
-from .models import Signature
-
+from .models import (
+    Signature,
+    EventSignature,
+)
+from func_sig_registry.utils.github import (
+    get_repository_solidity_files,
+)
 
 logger = logging.getLogger('bytes4.github_import')
 logger.setLevel(logging.INFO)
@@ -18,5 +23,14 @@ logger.addHandler(ch)
 
 @db_task()
 def perform_github_import(login_or_name, repository, branch):
-    logger.info("Importing github repo %s/%s/%s", login_or_name, repository, branch)
-    Signature.import_from_github_repository(login_or_name, repository, branch)
+    logger.info("Importing github repo %s/%s/%s", login_or_name,
+                repository, branch)
+    for file_path in get_repository_solidity_files(login_or_name, repository, branch):
+            logger.info("importing solidity file: %s", file_path)
+            with open(file_path) as solidity_file:
+                try:
+                    Signature.import_from_solidity_file(solidity_file)
+                    EventSignature.import_from_solidity_file(solidity_file)
+                except UnicodeDecodeError:
+                    logger.error('unicode error reading solidity file: %s',
+                                 file_path)

--- a/func_sig_registry/settings_test.py
+++ b/func_sig_registry/settings_test.py
@@ -7,8 +7,7 @@ os.environ.setdefault('DJANGO_SECURE_SSL_REDIRECT', 'False')
 os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
 os.environ.setdefault(
     'DATABASE_URL',
-    'postgres://postgres:postgres@localhost/func_sig_registry'
-    # 'postgres://{user}@localhost/func_sig_registry'.format(user=getpass.getuser()),
+    'postgres://{user}@localhost/func_sig_registry'.format(user=getpass.getuser()),
 )
 os.environ.setdefault('ROLLBAR_ACCESS_TOKEN', 'not-a-real-access-token')
 os.environ.setdefault('ROLLBAR_ENVIRONMENT', 'test')

--- a/func_sig_registry/settings_test.py
+++ b/func_sig_registry/settings_test.py
@@ -7,7 +7,8 @@ os.environ.setdefault('DJANGO_SECURE_SSL_REDIRECT', 'False')
 os.environ.setdefault('REDIS_URL', 'redis://localhost:6379')
 os.environ.setdefault(
     'DATABASE_URL',
-    'postgres://{user}@localhost/func_sig_registry'.format(user=getpass.getuser()),
+    'postgres://postgres:postgres@localhost/func_sig_registry'
+    # 'postgres://{user}@localhost/func_sig_registry'.format(user=getpass.getuser()),
 )
 os.environ.setdefault('ROLLBAR_ACCESS_TOKEN', 'not-a-real-access-token')
 os.environ.setdefault('ROLLBAR_ENVIRONMENT', 'test')

--- a/tests/web/github/test_get_repository_solidity_files.py
+++ b/tests/web/github/test_get_repository_solidity_files.py
@@ -11,4 +11,4 @@ def test_getting_repository_solidity_files():
         'pipermerriam',
         'ethereum-alarm-clock',
     ))
-    assert len(file_list) == 8
+    assert len(file_list) == 24


### PR DESCRIPTION
### What was wrong?
* Closes #76
* https://github.com/pipermerriam/ethereum-function-signature-registry/blob/19e582411af16d6e9bbe5665abfe99ee63b27bcb/tests/web/github/test_get_repository_solidity_files.py#L14
should be updated to 24
### How was it fixed?
* Changed https://github.com/pipermerriam/ethereum-function-signature-registry/blob/19e582411af16d6e9bbe5665abfe99ee63b27bcb/func_sig_registry/registry/tasks.py#L20 so that it looks for solidity files inside repository and calls `Signature.import_from_solidity_file(file_obj)` and `EventSignature.import_from_solidity_file(file_obj)`.
* `Signature.import_from_github_repository` and `EventSignature.import_from_github_repository` were removed
* Edited some logs
* Updated `test_get_repository_solidity_files.py`


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://live.staticflickr.com/7433/9324653982_084cacb8ec_b.jpg)
