### PR TITLE
Display user friendly error message for invalid signatures

### DIFF
--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -71,21 +71,21 @@ class AllSignatureCreateForm(serializers.Serializer):
 
     def validate_text_signature(self, value):
         validated_signatures = dict()
-        exceptions = []
+        exceptions_messages = []
         try:
             normalized_function_signature = normalize_function_signature(value)
             validated_signatures.update({'function_signature': normalized_function_signature})
         except ValueError as e:
-            exceptions.append(e)
+            exceptions_messages.append('Function import error: ' + str(e))
 
         try:
             normalized_event_signature = normalize_event_signature(value)
             validated_signatures.update({'event_signature': normalized_event_signature})
         except ValueError as e:
-            exceptions.append(e)
+            exceptions_messages.append('Event import error: ' + str(e))
 
         if len(validated_signatures) == 0:
-            raise ValueError(exceptions)
+            raise ValueError('. '.join(exceptions_messages))
         return validated_signatures
 
 

--- a/func_sig_registry/registry/forms.py
+++ b/func_sig_registry/registry/forms.py
@@ -76,16 +76,16 @@ class AllSignatureCreateForm(serializers.Serializer):
             normalized_function_signature = normalize_function_signature(value)
             validated_signatures.update({'function_signature': normalized_function_signature})
         except ValueError as e:
-            exceptions_messages.append('Function import error: ' + str(e))
+            exceptions_messages.append(f'Function import error: {str(e)}.')
 
         try:
             normalized_event_signature = normalize_event_signature(value)
             validated_signatures.update({'event_signature': normalized_event_signature})
         except ValueError as e:
-            exceptions_messages.append('Event import error: ' + str(e))
+            exceptions_messages.append(f'Event import error: {str(e)}.')
 
         if len(validated_signatures) == 0:
-            raise ValueError('. '.join(exceptions_messages))
+            raise ValueError(' '.join(exceptions_messages))
         return validated_signatures
 
 

--- a/func_sig_registry/registry/views.py
+++ b/func_sig_registry/registry/views.py
@@ -166,8 +166,17 @@ class SignatureCreateView(generics.CreateAPIView):
 
     def post(self, *args, **kwargs):
         serializer = self.get_serializer(data=self.request.data)
-        if not serializer.is_valid():
-            return Response({'serializer': serializer})
+
+        try:
+            if not serializer.is_valid():
+                return Response({'serializer': serializer})
+        except ValueError as e:
+            messages.error(
+                self.request._request,
+                str(e)
+            )
+            return redirect('/submit')
+
         function_signature, event_signature = serializer.save()
 
         # Check if any signatures were created, otherwise notify the user

--- a/tests/web/views/test_signature_submit.py
+++ b/tests/web/views/test_signature_submit.py
@@ -81,3 +81,17 @@ def test_only_event_siganture_created_notification():
     content = response.content.decode('utf-8')
     assert('Added event signature {0}'.format(normalized) in content)
     assert('Added function signature {0}.'.format(normalized) not in content)
+
+
+@pytest.mark.django_db
+def test_error_notification():
+    # Function signature should not be created because signature is anonymous.
+    signature = 'foo(List a)'
+
+    client = Client(HTTP_USER_AGENT='Mozilla/5.0', enforce_csrf_checks=True)
+    response = client.post('/submit/', {'text_signature': signature}, follow=True)
+
+    assert(response.status_code == status.HTTP_200_OK)
+    content = response.content.decode('utf-8')
+    assert('Function import error: function args contain non-standard types.' in content)
+    assert('Event import error: event args contain non-standard types' in content)


### PR DESCRIPTION
### What was wrong?

Whenever a user tries to submit an invalid signature, the user would receive an HTTP 500 error. 

### How was it fixed?

Instead of just throwing an exception, now it is caught and the exception message is displayed to the user. 

### To-Do

- [x] Display the error to the user
- [x] Add test cases 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.wired.com/photos/593261cab8eb31692072f129/master/pass/85120553.jpg)
