### PR TITLE
Updates the ABI schema to match Solidity 0.8.x

### DIFF
--- a/func_sig_registry/utils/abi.py
+++ b/func_sig_registry/utils/abi.py
@@ -33,6 +33,10 @@ ARGUMENT_SCHEMA = {
         'type': {
             'type': 'string',
         },
+        'components': {
+            'type': 'array',
+            'items': {'$ref': '#/definitions/argument'},
+        },
     },
     'required': ['name', 'type'],
 }
@@ -57,13 +61,25 @@ EVENT_ARGUMENT_SCHEMA = {
 FUNCTION_SCHEMA = {
     'type': 'object',
     'properties': {
-        'constant': BOOLEAN,
-        'type': {'type': 'string', 'enum': ['function']},
+        'type': {'type': 'string', 'enum': ['function','receive']},
         'inputs': INPUTS,
         'outputs': OUTPUTS,
         'name': NAME,
+        'stateMutability': {'type': 'string', 'enum': ['pure','view','nonpayable','payable']},
     },
-    'required': ['constant', 'type', 'inputs', 'outputs', 'name'],
+    'required': ['type', 'inputs', 'outputs', 'name'],
+    'definitions': {
+        'argument': ARGUMENT_SCHEMA,
+    },
+}
+
+FALLBACK_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'type': {'type': 'string', 'enum': ['fallback']},
+        'stateMutability': {'type': 'string', 'enum': ['pure','view','nonpayable','payable']},
+    },
+    'required': ['type'],
     'definitions': {
         'argument': ARGUMENT_SCHEMA,
     },
@@ -88,6 +104,7 @@ CONSTRUCTOR_SCHEMA = {
     'properties': {
         'type': {'type': 'string', 'enum': ['constructor']},
         'inputs': INPUTS,
+        'stateMutability': {'type': 'string', 'enum': ['pure','view','nonpayable','payable']},
     },
     'required': ['type', 'inputs'],
     'definitions': {
@@ -109,6 +126,7 @@ CONTRACT_ABI_SCHEMA = {
         'event': EVENT_SCHEMA,
         'constructor': CONSTRUCTOR_SCHEMA,
         'argument': ARGUMENT_SCHEMA,
+        'fallback': FALLBACK_SCHEMA,
     }
 }
 


### PR DESCRIPTION
* I added `stateMutability` but didn't mark it as required for backward compatibility with previous versions.
* I removed `constant` since it no longer is part of the schema.
* I added support for tuple types, but it is recursive and I'm not confident the way I wrote it will actually work.
* I added `receive` which shares a structure with `function`, so I didn't bother to create a new schema for it and instead just added it to a valid type for the `FUNCTION_SCHEMA`.

Latest spec pulled from: https://docs.soliditylang.org/en/latest/abi-spec.html#json

Hopefully fixes #92

### What was wrong?
ABI wasn't in line with latest ABI spec which was causing failures during import.

### How was it fixed?
Updating ABI to be in line with latest.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/8bvir3l2lye31.jpg)
