### PR TITLE
Fixing footer link

### DIFF
--- a/func_sig_registry/templates/partials/main_footer.html
+++ b/func_sig_registry/templates/partials/main_footer.html
@@ -1,5 +1,5 @@
 <div class="main-footer panel-footer text-right">
-  <a class="footer-item" href="https://github.com/pipermerriam/ethereum-function-signature-registry/issues/new">Github Project Page</a>
+  <a class="footer-item" href="https://github.com/pipermerriam/ethereum-function-signature-registry">Github Project Page</a>
   <a class="footer-item" href="https://github.com/pipermerriam/ethereum-function-signature-registry/issues/new">File an issue</a>
   <span class="footer-item">with ♥ by Snake Charmers</span>
 </div>


### PR DESCRIPTION
Bad footer link for the Github project page link.

### What was wrong?
Bad Link


### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://64.media.tumblr.com/97e7c3c941ab8dda9d2ee666057652ee/tumblr_nv3xi78u461sqjb2po1_540.jpg)
