### PR TITLE
adds multiple query `hex_signature__in` filter

### DIFF
--- a/func_sig_registry/registry/filters.py
+++ b/func_sig_registry/registry/filters.py
@@ -15,6 +15,7 @@ class SignatureFilter(filters.FilterSet):
     text_signature = filters.CharFilter(name='text_signature', lookup_type='icontains')
     bytes_signature = filters.MethodFilter()
     hex_signature = filters.MethodFilter()
+    hex_signature__in = filters.MethodFilter()
 
     class Meta:
         model = Signature
@@ -33,6 +34,10 @@ class SignatureFilter(filters.FilterSet):
             return qs.filter(bytes_signature__hex_signature=unprefixed_value)
         else:
             return qs.filter(bytes_signature__hex_signature__icontains=unprefixed_value)
+
+    def filter_hex_signature__in(self, name, qs, values):
+        unprefixed_values = [remove_0x_prefix(value.lower()) for value in values.split(',')]
+        return qs.filter(bytes_signature__hex_signature__in=unprefixed_values)
 
 
 class EventSignatureFilter(filters.FilterSet):

--- a/func_sig_registry/templates/documentation.html
+++ b/func_sig_registry/templates/documentation.html
@@ -127,6 +127,17 @@
         <li>If the provided query is less than 4 bytes long then the results are filtered by substring match.</li>
         <li>If the provided query is longer than 4 bytes then the results are not filtered since it is an invalid query.</li>
       </ul>
+      <h4>Filtering on multiple <code>hex_signatures</code></h4>
+      <p>Match multiple queries using the <code>hex_signature__in</code> filter with multiple comma delimited <code>hex_signatures</code>.</p>
+      <blockquote><code>/api/v1/signatures/?hex_signature__in=0xabcd1234,0xefgh6789</code></blockquote>
+      <div class="alert alert-info" role="alert">
+        <p>The <code>0x</code> prefix on the query value is optional.</p>
+      </div>
+      <p>
+        <ul>
+          <li>The provided queries must be exactly 4 bytes. Substring matches not allowed with multiple query search.</li>
+        </ul>
+      <p>
       <h2>Creating Signatures <code>/api/v1/signatures/</code> <span class="label label-primary">POST</span></h2>
       <p>Creates a new signature</p>
       <h3>Example Request</h3>
@@ -186,7 +197,7 @@
       <li><code>text_signature</code> (string): The text representation of the event signature.</li>
       <li><code>bytes_signature</code> (string): The 32-byte event selector</li>
       <li><code>hex_signature</code> (string): The hex encoded 32-byte event selector.</li>
-    </ul>  
+    </ul>
 <pre>{
   "id": 19,
   "created_at": "2020-09-13T18:45:58.559831Z",

--- a/tests/web/api/test_searching_signature_api_view.py
+++ b/tests/web/api/test_searching_signature_api_view.py
@@ -36,6 +36,46 @@ def test_exact_without_0x_hex_search(api_client, factories):
     assert result['id'] == s2.id
 
 
+def test_multiple_exact_hex_search(api_client, factories):
+    list_url = reverse('api:signature-list')
+    s1, s2, s3, s4, s5 = factories.SignatureFactory.create_batch(5)
+
+    search_url = list_url + '?hex_signature__in={0},{1},{2}'.format(
+        s2.bytes_signature.get_hex_display(),
+        s4.bytes_signature.get_hex_display(),
+        s5.bytes_signature.get_hex_display(),
+    )
+    response = api_client.get(search_url)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.data
+    assert data['count'] == 3
+    actual_results = sorted([item['id'] for item in data['results']])
+    assert len(actual_results) == 3
+    expected_results = sorted([s2.id, s4.id, s5.id])
+    assert actual_results == expected_results
+
+
+def test_multiple_exact_without_0x_hex_search(api_client, factories):
+    list_url = reverse('api:signature-list')
+    s1, s2, s3, s4, s5 = factories.SignatureFactory.create_batch(5)
+
+    search_url = list_url + '?hex_signature__in={0},{1},{2}'.format(
+        s1.bytes_signature.get_hex_display()[2:],
+        s3.bytes_signature.get_hex_display()[2:],
+        s4.bytes_signature.get_hex_display()[2:],
+    )
+    response = api_client.get(search_url)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.data
+    assert data['count'] == 3
+    actual_results = sorted([item['id'] for item in data['results']])
+    assert len(actual_results) == 3
+    expected_results = sorted([s1.id, s3.id, s4.id])
+    assert actual_results == expected_results
+
+
 def test_substring_hex_search_with_0x(api_client, factories):
     list_url = reverse('api:signature-list')
     s1, s2, s3, s4, s5 = factories.SignatureFactory.create_batch(5)


### PR DESCRIPTION
### What was wrong?
This is an enhancement to allow query by multiple hex_signatures using `hex_signature__in`


### How was it fixed?
A new method filter was added to the SignatureFilterset
Tests were added
Documentation was updated

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i1.wp.com/www.dailycal.org/assets/uploads/2019/10/animals_wikimedia_cc.jpg?ssl=1&w=900)
